### PR TITLE
Add repo mirror

### DIFF
--- a/.github/workflows/repo-mirror.yml
+++ b/.github/workflows/repo-mirror.yml
@@ -1,0 +1,25 @@
+name: Openeuler gitee repos mirror periodic job
+
+on:
+  pull_request:
+    # Runs at every pull requests submitted in master branch 
+    branches: [ master ]
+  schedule:
+    # Runs at 01:00 UTC (9:00 AM Beijing) every day
+    - cron:  '0 1 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Mirror the gitee/openeuler org repos to github/openeuler-mirror.
+      uses: Yikun/hub-mirror-action@v0.04
+      with:
+        src: gitee/openeuler
+        dst: github/openeuler-mirror
+        dst_key: ${{ secrets.SYNC_EULER_PRIVATE_KEY }}
+        dst_token:  ${{ secrets.SYNC_EULER_TOKEN }}
+        account_type: org
+        clone_style: ssh


### PR DESCRIPTION
This patch adds the repo mirror workflow for openeuler.

This action will executed in every master pull requests and 01:00 UTC (9:00 AM Beijing) every day.

Note that we have to use the ssh to clone the kernel project, so we use the `ssh` clone style in here.