### PR TITLE
Add cache support for openeuler

### DIFF
--- a/.github/workflows/repo-mirror.yml
+++ b/.github/workflows/repo-mirror.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     # Runs at every pull requests submitted in master branch 
     branches: [ master ]
+    paths:
+    - '.github/workflows/**'
   schedule:
     # Runs at 01:00 UTC (9:00 AM Beijing) every day
     - cron:  '0 1 * * *'

--- a/.github/workflows/repo-mirror.yml
+++ b/.github/workflows/repo-mirror.yml
@@ -21,7 +21,7 @@ jobs:
         key: ${{ runner.os }}-openeuler-repos-cache
 
     - name: Mirror the gitee/openeuler org repos to github/openeuler-mirror.
-      uses: Yikun/hub-mirror-action@v0.04
+      uses: Yikun/hub-mirror-action@v0.05
       with:
         src: gitee/openeuler
         dst: github/openeuler-mirror

--- a/.github/workflows/repo-mirror.yml
+++ b/.github/workflows/repo-mirror.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Cache src repos
+      uses: actions/cache@v1
+      with:
+        path: /home/runner/work/hub-mirror-action/hub-mirror-action/openeuler-cache
+        key: ${{ runner.os }}-openeuler-repos-cache
+
     - name: Mirror the gitee/openeuler org repos to github/openeuler-mirror.
       uses: Yikun/hub-mirror-action@v0.04
       with:
@@ -23,3 +29,4 @@ jobs:
         dst_token:  ${{ secrets.SYNC_EULER_TOKEN }}
         account_type: org
         clone_style: ssh
+        cache_path: /github/workspace/openeuler-cache

--- a/.github/workflows/repo-mirror.yml
+++ b/.github/workflows/repo-mirror.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Cache src repos
       uses: actions/cache@v1
       with:
-        path: /home/runner/work/hub-mirror-action/hub-mirror-action/openeuler-cache
+        path: /home/runner/work/sync-config/sync-config/openeuler-cache
         key: ${{ runner.os }}-openeuler-repos-cache
 
     - name: Mirror the gitee/openeuler org repos to github/openeuler-mirror.


### PR DESCRIPTION
This patch add the cache support for Openeuler to speed up the mirror. All src repos will stored in /github/workspace/openeuler-cache, and action/cache will help save and store the cache.

This patch bump the hub-mirror-action to v0.05 to enable the cache path feature, see more in https://github.com/Yikun/hub-mirror-action/issues/13
